### PR TITLE
Fixed exports, of member functions and Data.Reflection.Reifies

### DIFF
--- a/src/Polysemy/MTL.hs
+++ b/src/Polysemy/MTL.hs
@@ -30,6 +30,8 @@ module Polysemy.MTL
   , Reifies
   , (:-)(Sub)
   , Dict(Dict)
+  , reflect
+  , Proxy (Proxy)
   )
 where
 
@@ -43,7 +45,7 @@ import           Data.Constraint (Dict(Dict),(:-)(Sub),(\\))
 import qualified Data.Constraint.Unsafe as C
 import           Data.Proxy (Proxy (..))
 import qualified Data.Reflection as R
-import           Data.Reflection (Reifies) 
+import           Data.Reflection (Reifies, reflect) 
 import           Data.Kind (Type, Constraint)
 
 import           Polysemy

--- a/src/Polysemy/MTL.hs
+++ b/src/Polysemy/MTL.hs
@@ -13,7 +13,7 @@ module Polysemy.MTL
   (
     -- * Types
     CanonicalEffect
-  , ConstrainedAction
+  , ConstrainedAction (..)
   , ReifiableConstraint1 (..)
   , IsCanonicalEffect (..)
 
@@ -28,6 +28,8 @@ module Polysemy.MTL
 
     -- * Re-exports
   , Reifies
+  , (:-)(Sub)
+  , Dict(Dict)
   )
 where
 
@@ -37,7 +39,7 @@ import qualified Control.Monad.State.Class as S
 import qualified Control.Monad.Writer.Class as S
 import qualified Control.Monad.Error.Class as S
 import qualified Data.Constraint as C
-import           Data.Constraint ((:-),(\\))
+import           Data.Constraint (Dict(Dict),(:-)(Sub),(\\))
 import qualified Data.Constraint.Unsafe as C
 import           Data.Proxy (Proxy (..))
 import qualified Data.Reflection as R
@@ -81,8 +83,8 @@ newtype ConstrainedAction (p :: (Type -> Type) -> Constraint)
 -- containing the dictionary signatures as a record of functions and the
 -- reflected entailment of @p (ConstrainedAction p m r)@ from the reified dictionary.
 class ReifiableConstraint1 p where
-  data Dict (p :: (Type -> Type) -> Constraint) (m :: Type -> Type)
-  reifiedInstance :: Monad m => R.Reifies s (Dict p m) :- p (ConstrainedAction p m s)
+  data Dict1 (p :: (Type -> Type) -> Constraint) (m :: Type -> Type)
+  reifiedInstance :: Monad m => R.Reifies s (Dict1 p m) :- p (ConstrainedAction p m s)
 
 -- | This class contains an instance of the dictionary for some set of effects
 -- parameterized by a polysemy effect list @r@.
@@ -90,11 +92,11 @@ class ReifiableConstraint1 p where
 -- satisfying the constraint that the "canonical" effect is a member.  But you
 -- could also use it to discharge constraints which require multiple polysemy effects.
 class ReifiableConstraint1 p => IsCanonicalEffect p r where
-  canonicalDictionary :: Dict p (Sem r)
+  canonicalDictionary :: Dict1 p (Sem r)
 
 -- | Given a reifiable constraint, and a dictionary to use, discharge the constraint.
 using :: forall p m a. (Monad m, ReifiableConstraint1 p)
-  => Dict p m -> (p m => m a) -> m a
+  => Dict1 p m -> (p m => m a) -> m a
 using d m =
   R.reify d $ \(_ :: Proxy s) -> m \\ C.trans
   (C.unsafeCoerceConstraint :: ((p (ConstrainedAction p m s) :- p m))) reifiedInstance
@@ -113,14 +115,14 @@ absorbReader = absorb @(S.MonadReader _)
 {-# INLINEABLE absorbReader #-}
 
 instance ReifiableConstraint1 (S.MonadReader i) where
-  data Dict (S.MonadReader i) m = MonadReader
+  data Dict1 (S.MonadReader i) m = MonadReader
     { ask_ :: m i
     , local_ :: forall a. (i -> i) -> m a -> m a
     }
-  reifiedInstance = C.Sub C.Dict
+  reifiedInstance = Sub Dict
 
 instance ( Monad m
-         , R.Reifies s' (Dict (S.MonadReader i) m)
+         , R.Reifies s' (Dict1 (S.MonadReader i) m)
          ) => S.MonadReader i (ConstrainedAction (S.MonadReader i) m s') where
   ask = ConstrainedAction $ ask_ $ R.reflect $ Proxy @s'
   {-# INLINEABLE ask #-}
@@ -137,14 +139,14 @@ absorbState = absorb @(S.MonadState _)
 {-# INLINEABLE absorbState #-}
 
 instance ReifiableConstraint1 (S.MonadState s) where
-  data Dict (S.MonadState s) m = MonadState
+  data Dict1 (S.MonadState s) m = MonadState
     { get_ :: m s
     , put_ :: s -> m ()
     }
-  reifiedInstance = C.Sub C.Dict
+  reifiedInstance = Sub Dict
 
 instance ( Monad m
-         , R.Reifies s' (Dict (S.MonadState s) m)
+         , R.Reifies s' (Dict1 (S.MonadState s) m)
          ) => S.MonadState s (ConstrainedAction (S.MonadState s) m s') where
   get = ConstrainedAction $ get_ $ R.reflect $ Proxy @s'
   {-# INLINEABLE get #-}  
@@ -162,16 +164,16 @@ absorbWriter = absorb @(S.MonadWriter _)
 {-# INLINEABLE absorbWriter #-}
 
 instance Monoid w => ReifiableConstraint1 (S.MonadWriter w) where
-  data Dict (S.MonadWriter w) m = MonadWriter
+  data Dict1 (S.MonadWriter w) m = MonadWriter
     { tell_ :: w -> m ()
     , listen_ :: forall a. m a -> m (a, w)
     , pass_ :: forall a. m (a, w -> w) -> m a 
     }
-  reifiedInstance = C.Sub C.Dict
+  reifiedInstance = Sub Dict
 
 instance ( Monad m
          , Monoid w
-         , R.Reifies s' (Dict (S.MonadWriter w) m)
+         , R.Reifies s' (Dict1 (S.MonadWriter w) m)
          ) => S.MonadWriter w (ConstrainedAction (S.MonadWriter w) m s') where
   tell w = ConstrainedAction $ tell_ (R.reflect $ Proxy @s') w
   {-# INLINEABLE tell #-}  
@@ -199,14 +201,14 @@ absorbError = absorb @(S.MonadError e)
 {-# INLINEABLE absorbError #-}
 
 instance ReifiableConstraint1 (S.MonadError e) where
-  data Dict (S.MonadError e) m = MonadError
+  data Dict1 (S.MonadError e) m = MonadError
     { throwError_ :: forall a. e -> m a
     , catchError_ :: forall a. m a -> (e -> m a) -> m a
     }
-  reifiedInstance = C.Sub C.Dict
+  reifiedInstance = Sub Dict
 
 instance ( Monad m
-         , R.Reifies s' (Dict (S.MonadError e) m)
+         , R.Reifies s' (Dict1 (S.MonadError e) m)
          ) => S.MonadError e (ConstrainedAction (S.MonadError e) m s') where
   throwError e = ConstrainedAction $ throwError_ (R.reflect $ Proxy @s') e
   {-# INLINEABLE throwError #-}

--- a/src/Polysemy/MTL.hs
+++ b/src/Polysemy/MTL.hs
@@ -14,8 +14,8 @@ module Polysemy.MTL
     -- * Types
     CanonicalEffect
   , ConstrainedAction
-  , ReifiableConstraint1
-  , IsCanonicalEffect
+  , ReifiableConstraint1 (..)
+  , IsCanonicalEffect (..)
 
     -- * constraint-polymorphic absorber
   , absorb
@@ -25,6 +25,9 @@ module Polysemy.MTL
   , absorbState
   , absorbWriter
   , absorbError
+
+    -- * Re-exports
+  , Reifies
   )
 where
 
@@ -38,6 +41,7 @@ import           Data.Constraint ((:-),(\\))
 import qualified Data.Constraint.Unsafe as C
 import           Data.Proxy (Proxy (..))
 import qualified Data.Reflection as R
+import           Data.Reflection (Reifies) 
 import           Data.Kind (Type, Constraint)
 
 import           Polysemy


### PR DESCRIPTION
Sorry about this.  Was preparing to add tests for and re-submit the RandomFu stuff and ran into the fact that I forgot to export some necessary things for making absorbers in other modules using ```Polysemy.MTL```
I think that's fixed here.  And I've added the labor-saving export of ```Data.Reflection.Reifies```