### PR TITLE
Continuation Effects

### DIFF
--- a/polysemy-zoo.cabal
+++ b/polysemy-zoo.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0929c117380e23068acf92052428f29caedeba9039e34f4d6f3f9b3103d6c504
+-- hash: 70cb20c0ec0199dac4a299ba0ecfa3cdc0f97bf0c4ba45a5a88b880dc1c1b1b8
 
 name:           polysemy-zoo
 version:        0.4.0.1
@@ -80,12 +80,15 @@ test-suite polysemy-zoo-test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      CaptureSpec
       ConstraintAbsorberSpec
+      ContSpec
       FinalSpec
       FloodgateSpec
       IdempotentLoweringSpec
       KVStoreSpec
       SeveralSpec
+      ShiftSpec
       Paths_polysemy_zoo
   hs-source-dirs:
       test

--- a/polysemy-zoo.cabal
+++ b/polysemy-zoo.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9c68e7c2421eb030fe99a14dcd7cc393f3aaf7a1f3874b559a2222ba3073e8ae
+-- hash: 0929c117380e23068acf92052428f29caedeba9039e34f4d6f3f9b3103d6c504
 
 name:           polysemy-zoo
 version:        0.4.0.1
@@ -30,11 +30,14 @@ source-repository head
 library
   exposed-modules:
       Polysemy.Alias
+      Polysemy.Capture
       Polysemy.ConstraintAbsorber
       Polysemy.ConstraintAbsorber.MonadError
       Polysemy.ConstraintAbsorber.MonadReader
       Polysemy.ConstraintAbsorber.MonadState
       Polysemy.ConstraintAbsorber.MonadWriter
+      Polysemy.Cont
+      Polysemy.Cont.Internal
       Polysemy.Final
       Polysemy.Final.Async
       Polysemy.Final.Error
@@ -49,6 +52,8 @@ library
       Polysemy.Redis.Utils
       Polysemy.SetStore
       Polysemy.Several
+      Polysemy.Shift
+      Polysemy.Shift.Internal
   other-modules:
       Paths_polysemy_zoo
   hs-source-dirs:

--- a/polysemy-zoo.cabal
+++ b/polysemy-zoo.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 70cb20c0ec0199dac4a299ba0ecfa3cdc0f97bf0c4ba45a5a88b880dc1c1b1b8
+-- hash: ea3072227c7af490e7767e57c2ebeb214aad437a3f89fc82c4eac1ae476567c7
 
 name:           polysemy-zoo
 version:        0.4.0.1

--- a/polysemy-zoo.cabal
+++ b/polysemy-zoo.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ea3072227c7af490e7767e57c2ebeb214aad437a3f89fc82c4eac1ae476567c7
+-- hash: 55c7f7a73e39069f21ba6722b93363a4260914f22f82f16a90e034d3db955105
 
 name:           polysemy-zoo
 version:        0.4.0.1

--- a/src/Polysemy/Capture.hs
+++ b/src/Polysemy/Capture.hs
@@ -28,9 +28,9 @@ import Polysemy.Internal.Union
 import Polysemy.Cont.Internal(Ref(..))
 
 -----------------------------------------------------------------------------
--- | A less powerful variant of 'Shift' that may always be interpreted
--- safely. Unlike 'Shift', continuations can't leave the scope in which
--- they are provided.
+-- | A less powerful variant of 'Polysemy.Shift.Shift' that may always be
+-- interpreted safely. Unlike 'Polysemy.Shift.Shift',
+-- continuations can't leave the scope in which they are provided.
 --
 -- __Note__: Any computation used in a higher-order effect will
 -- be delimited.
@@ -84,7 +84,7 @@ delimit' :: forall ref a r
          -> Sem r (Maybe a)
 
 -----------------------------------------------------------------------------
--- | A restricted version of 'shift'.
+-- | A restricted version of 'Polysemy.Shift.shift'.
 -- Executing the provided continuation will not abort execution.
 --
 -- The provided continuation may fail locally in its subcontinuations.

--- a/src/Polysemy/Capture.hs
+++ b/src/Polysemy/Capture.hs
@@ -32,6 +32,9 @@ import Polysemy.Cont.Internal(Ref(..))
 -- safely. Unlike 'Shift', continuations can't leave the scope in which
 -- they are provided.
 --
+-- __Note__: Any computation used in a higher-order effect will
+-- be delimited.
+--
 -- Activating polysemy-plugin is highly recommended when using this effect
 -- in order to avoid ambiguous types.
 data Capture ref m a where

--- a/src/Polysemy/Capture.hs
+++ b/src/Polysemy/Capture.hs
@@ -46,7 +46,7 @@ data Capture ref m a where
 makeSem_ ''Capture
 
 -----------------------------------------------------------------------------
--- Reifies the current continuation in the form of a prompt, and passes it to
+-- | Reifies the current continuation in the form of a prompt, and passes it to
 -- the first argument.
 reify :: forall ref a r
       .  Member (Capture ref) r
@@ -54,7 +54,7 @@ reify :: forall ref a r
       -> Sem r a
 
 -----------------------------------------------------------------------------
--- Provide an answer to a prompt, jumping to its reified continuation.
+-- | Provide an answer to a prompt, jumping to its reified continuation.
 -- This will not abort the current continuation, and the
 -- reified computation will return its final result when finished.
 --
@@ -69,14 +69,14 @@ reflect :: forall ref a x r
         -> Sem r a
 
 -----------------------------------------------------------------------------
--- Delimits any continuations
+-- | Delimits any continuations
 delimit :: forall ref a r
         .  Member (Capture ref) r
         => Sem r a
         -> Sem r a
 
 -----------------------------------------------------------------------------
--- Delimits any continuations, and detects if any subcontinuation
+-- | Delimits any continuations, and detects if any subcontinuation
 -- has failed locally.
 delimit' :: forall ref a r
          .  Member (Capture ref) r

--- a/src/Polysemy/Capture.hs
+++ b/src/Polysemy/Capture.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Polysemy.Capture
+  (-- * Effect
+    Capture(..)
+
+    -- * Actions
+  , reify
+  , reflect
+  , delimit
+  , delimit'
+  , capture
+
+    -- * Interpretations
+  , runCapture
+  , runCaptureWithC
+
+  -- * Prompt types
+  , Ref(..)
+  ) where
+
+import Control.Monad
+import Control.Monad.Cont (ContT(..))
+
+import Polysemy
+import Polysemy.Internal
+import Polysemy.Internal.Union
+
+import Polysemy.Cont.Internal(Ref(..))
+
+-----------------------------------------------------------------------------
+-- | A less powerful variant of 'Shift' that may always be interpreted
+-- safely. Unlike 'Shift', continuations can't leave the scope in which
+-- they are provided.
+--
+-- Activating polysemy-plugin is highly recommended when using this effect
+-- in order to avoid ambiguous types.
+data Capture ref m a where
+  Reify    :: (forall s. ref s a -> m s) -> Capture ref m a
+  Reflect  :: ref s a -> a -> Capture ref m s
+  Delimit  :: m a -> Capture ref m a
+  Delimit' :: m a -> Capture ref m (Maybe a)
+
+makeSem_ ''Capture
+
+-----------------------------------------------------------------------------
+-- Reifies the current continuation in the form of a prompt, and passes it to
+-- the first argument.
+reify :: forall ref a r
+      .  Member (Capture ref) r
+      => (forall s. ref s a -> Sem r s)
+      -> Sem r a
+
+-----------------------------------------------------------------------------
+-- Provide an answer to a prompt, jumping to its reified continuation.
+-- This will not abort the current continuation, and the
+-- reified computation will return its final result when finished.
+--
+-- The provided continuation may fail locally in its subcontinuations.
+-- It may sometimes become necessary to handle such cases. To do so,
+-- use 'delimit\'' together with 'reflect' (the reified continuation
+-- is already delimited).
+reflect :: forall ref a x r
+        .  Member (Capture ref) r
+        => ref a x
+        -> x
+        -> Sem r a
+
+-----------------------------------------------------------------------------
+-- Delimits any continuations
+delimit :: forall ref a r
+        .  Member (Capture ref) r
+        => Sem r a
+        -> Sem r a
+
+-----------------------------------------------------------------------------
+-- Delimits any continuations, and detects if any subcontinuation
+-- has failed locally.
+delimit' :: forall ref a r
+         .  Member (Capture ref) r
+         => Sem r a
+         -> Sem r (Maybe a)
+
+-----------------------------------------------------------------------------
+-- | A restricted version of 'shift'.
+-- Executing the provided continuation will not abort execution.
+--
+-- The provided continuation may fail locally in its subcontinuations.
+-- It may sometimes become necessary to handle such cases, in
+-- which case such failure may be detected by using 'delimit\'' together
+-- with the provided continuation (the provided continuation
+-- is already delimited).
+capture :: Member (Capture ref) r
+        => (forall s. (a -> Sem r s) -> Sem r s)
+        -> Sem r a
+capture cc = reify (\ref -> cc (reflect ref))
+{-# INLINE capture #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Capture' effect by providing 'pure '.' Just' as the final
+-- continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+runCapture :: Sem (Capture (Ref (Sem r))': r) a -> Sem r (Maybe a)
+runCapture = runCaptureWithC (pure . Just)
+{-# INLINE runCapture #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Capture' effect by explicitly providing a final
+-- continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+runCaptureWithC :: (a -> Sem r (Maybe s))
+                -> Sem (Capture (Ref (Sem r)) ': r) a
+                -> Sem r (Maybe s)
+runCaptureWithC c (Sem m) = (`runContT` c) $ m $ \u ->
+    case decomp u of
+      Right (Weaving e s wv ex ins) ->
+        ContT $ \c' ->
+          case e of
+            Reflect ref a ->
+                  runRef ref a
+              >>= c' . ex . (<$ s)
+            Reify main ->
+              runCaptureWithC
+                (pure . join . ins)
+                (wv (main (Ref (c' . ex . (<$ s))) <$ s))
+            Delimit main ->
+                  runCaptureWithC
+                    (pure . Just)
+                    (wv (main <$ s))
+              >>= maybe (pure Nothing) (c' . ex)
+            Delimit' main ->
+                  runCaptureWithC
+                    (pure . Just)
+                    (wv (main <$ s))
+              >>= maybe (c' (ex (Nothing <$ s))) (c' . ex . fmap Just)
+      Left g -> ContT $ \c' ->
+            liftSem (weave (Just ()) (maybe (pure Nothing) runCapture) id g)
+        >>= maybe (pure Nothing) c'
+{-# INLINE runCaptureWithC #-}

--- a/src/Polysemy/Cont.hs
+++ b/src/Polysemy/Cont.hs
@@ -34,6 +34,13 @@ import qualified Control.Monad.Cont as C (callCC)
 -- | Call with current continuation.
 -- Executing the provided continuation will abort execution.
 --
+-- Using the provided continuation
+-- will rollback all effectful state back to the point where 'callCC' was invoked,
+-- unless such state is interpreted in terms of the final
+-- monad, /or/ the associated interpreter of the effectful state
+-- is run after 'runContUnsafe', which may be done if the effect isn't
+-- higher-order.
+--
 -- Higher-order effects do not interact with the continuation in any meaningful
 -- way; i.e. 'Polysemy.Reader.local' or 'Polysemy.Writer.censor' does not affect
 -- it, and 'Polysemy.Error.catch' will fail to catch any of its exceptions.
@@ -100,4 +107,3 @@ runContFinal = interpretFinal $ \case
 runContUnsafe :: Sem (Cont (Ref (Sem r) a) ': r) a -> Sem r a
 runContUnsafe = runContWithCUnsafe pure
 {-# INLINE runContUnsafe #-}
-

--- a/src/Polysemy/Cont.hs
+++ b/src/Polysemy/Cont.hs
@@ -1,0 +1,103 @@
+module Polysemy.Cont
+  (-- * Effect
+    Cont(..)
+
+    -- * Actions
+  , jump
+  , subst
+  , callCC
+
+    -- * Interpretations
+  , runContPure
+  , runContM
+  , runContFinal
+
+    -- * Unsafe Interpretations
+  , runContUnsafe
+
+  -- * Prompt types
+  , Ref(..)
+  , ExitRef(..)
+  ) where
+
+import Data.Void
+
+import Polysemy
+import Polysemy.Final
+
+import Polysemy.Cont.Internal
+
+import Control.Monad.Cont (MonadCont())
+import qualified Control.Monad.Cont as C (callCC)
+
+-----------------------------------------------------------------------------
+-- | Call with current continuation.
+-- Executing the provided continuation will abort execution.
+--
+-- Higher-order effects do not interact with the continuation in any meaningful
+-- way; i.e. 'Polysemy.Reader.local' or 'Polysemy.Writer.censor' does not affect
+-- it, and 'Polysemy.Error.catch' will fail to catch any of its exceptions.
+-- The only exception to this is if you interpret such effects /and/ 'Cont'
+-- in terms of the final monad, and the final monad can perform such interactions
+-- in a meaningful manner.
+callCC :: forall ref a r.
+          Member (Cont ref) r
+       => ((forall b. a -> Sem r b) -> Sem r a)
+       -> Sem r a
+callCC cc = subst (\ref -> cc (jump ref)) pure
+{-# INLINE callCC #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Cont' effect by providing 'pure' as the final continuation.
+--
+-- This is a safe variant of 'runContUnsafe', as this may only be used
+-- as the final interpreter before 'run'.
+runContPure :: Sem '[Cont (Ref (Sem '[]) a)] a -> Sem '[] a
+runContPure = runContUnsafe
+{-# INLINE runContPure #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Cont' effect by providing 'pure' as the final continuation.
+--
+-- This is a safe variant of 'runContUnsafe', as this may only be used
+-- as the final interpreter before 'runM'.
+runContM :: Sem '[Cont (Ref (Sem '[Lift m]) a), Lift m] a -> Sem '[Lift m] a
+runContM = runContUnsafe
+{-# INLINE runContM #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Cont' effect in terms of a final 'MonadCont'
+--
+-- /Beware/: Effects that aren't interpreted in terms of the final monad
+-- will have local state semantics in regards to 'Cont' effects
+-- interpreted this way. See 'interpretFinal'.
+runContFinal :: (Member (Final m) r, MonadCont m)
+             => Sem (Cont (ExitRef m) ': r) a
+             -> Sem r a
+runContFinal = interpretFinal $ \case
+  Jump ref a    -> pure $ enterExit ref a
+  Subst main cb -> do
+    main' <- bindS main
+    cb'   <- bindS cb
+    s     <- getInitialStateS
+    pure $ C.callCC $ \exit ->
+      main' (ExitRef (\a -> cb' (a <$ s) >>= vacuous . exit) <$ s)
+{-# INLINE runContFinal #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Cont' effect by providing 'pure' as the final continuation.
+--
+-- __Beware__: This interpreter will invalidate all higher-order effects of any
+-- interpreter run after it; i.e. 'Polysemy.Reader.local' and
+-- 'Polysemy.Writer.censor' will be no-ops, 'Polysemy.Error.catch' will fail
+-- to catch exceptions, and 'Polysemy.Writer.listen' will always return 'mempty'.
+--
+-- __You should therefore use 'runContUnsafe' /after/ running all interpreters for
+-- your higher-order effects.__
+--
+-- Note that 'Final' is a higher-order effect, and thus 'runContUnsafe' can't
+-- safely be used together with 'runFinal'.
+runContUnsafe :: Sem (Cont (Ref (Sem r) a) ': r) a -> Sem r a
+runContUnsafe = runContWithCUnsafe pure
+{-# INLINE runContUnsafe #-}
+

--- a/src/Polysemy/Cont/Internal.hs
+++ b/src/Polysemy/Cont/Internal.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Polysemy.Cont.Internal where
+
+import Polysemy
+import Polysemy.Internal
+import Polysemy.Internal.Union
+import Control.Monad
+import Control.Monad.Cont (ContT(..))
+
+-----------------------------------------------------------------------------
+-- | An effect for abortive continuations, formulated a là BLABLA
+--
+-- Activating polysemy-plugin is highly recommended when using this effect
+-- in order to avoid ambiguous types.
+data Cont ref m a where
+  Jump    :: ref a -> a -> Cont ref m b
+  Subst   :: (ref a -> m b) -> (a -> m b) -> Cont ref m b
+
+makeSem_ ''Cont
+
+-----------------------------------------------------------------------------
+-- Provide an answer to a prompt, jumping to its reified continuation,
+-- and aborting the current continuation.
+--
+-- Higher-order effects do not interact with the continuation in any meaningful
+-- way; i.e. 'Polysemy.Reader.local' or 'Polysemy.Writer.censor' does not affect
+-- it, and 'Polysemy.Error.catch' will fail to catch any of its exceptions.
+-- The only exception to this is if you interpret such effects /and/ 'Cont'
+-- in terms of the final monad, and the final monad can perform such interactions
+-- in a meaningful manner.
+jump :: forall ref x a r.
+        Member (Cont ref) r
+     => ref x
+     -> x
+     -> Sem r a
+
+-----------------------------------------------------------------------------
+-- Reifies the current continuation in the form of a prompt, and passes it to
+-- the first argument. If the prompt becomes invoked via 'jump', then the
+-- second argument will be run before the reified continuation, and otherwise
+-- will not be called at all.
+subst :: forall ref x a r.
+         Member (Cont ref) r
+      => (ref x -> Sem r a)
+      -> (x -> Sem r a)
+      -> Sem r a
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Cont' effect by providing a final continuation.
+--
+-- __Beware__: This interpreter will invalidate all higher-order effects of any
+-- interpreter run after it; i.e. 'Polysemy.Reader.local' and
+-- 'Polysemy.Writer.censor' will be no-ops, 'Polysemy.Error.catch' will fail
+-- to catch exceptions, and 'Polysemy.Writer.listen' will always return 'mempty'.
+--
+-- __You should therefore use 'runContUnsafeWithC' /after/ running all interpreters
+-- for your higher-order effects.__
+runContWithCUnsafe :: (a -> Sem r s) -> Sem (Cont (Ref (Sem r) s) ': r) a -> Sem r s
+runContWithCUnsafe c (Sem m) = (`runContT` c) $ m $ \u -> case decomp u of
+  Right weaving -> runContWeaving runContWithCUnsafe weaving
+  Left g -> ContT $ \c' -> embedSem g >>= runContWithCUnsafe c'
+{-# INLINE runContWithCUnsafe #-}
+
+runContWeaving :: Monad m
+               => (forall x. (x -> m s) -> Sem r x -> m s)
+               -> Weaving (Cont (Ref m s)) (Sem r) a
+               -> ContT s m a
+runContWeaving runW (Weaving e s wv ex _) =
+    ContT $ \c ->
+      case e of
+        Jump ref a    -> runRef ref a
+        Subst main cb ->
+          let
+            callback a = runW (c . ex) (wv (cb a <$ s))
+          in
+            runW (c . ex) (wv (main (Ref callback) <$ s))
+{-# INLINE runContWeaving #-}
+
+inspectSem :: Sem r a -> Maybe a
+inspectSem (Sem m) = m (\_ -> Nothing)
+{-# INLINE inspectSem #-}
+
+embedSem :: Union r (Sem r') a -> Sem r (Sem r' a)
+embedSem = liftSem . weave (pure ()) (pure . join) inspectSem
+{-# INLINE embedSem #-}
+
+newtype Ref m s a = Ref { runRef :: a -> m s }
+newtype ExitRef m a = ExitRef { enterExit :: forall b. a -> m b }

--- a/src/Polysemy/Cont/Internal.hs
+++ b/src/Polysemy/Cont/Internal.hs
@@ -19,8 +19,14 @@ data Cont ref m a where
 makeSem_ ''Cont
 
 -----------------------------------------------------------------------------
--- Provide an answer to a prompt, jumping to its reified continuation,
+-- | Provide an answer to a prompt, jumping to its reified continuation,
 -- and aborting the current continuation.
+--
+-- Using 'jump' will rollback all effectful state back to the point where the
+-- prompt was created, unless such state is interpreted in terms of the final
+-- monad, /or/ the associated interpreter of the effectful state
+-- is run after 'runContUnsafe', which may be done if the effect isn't
+-- higher-order.
 --
 -- Higher-order effects do not interact with the continuation in any meaningful
 -- way; i.e. 'Polysemy.Reader.local' or 'Polysemy.Writer.censor' does not affect
@@ -35,7 +41,7 @@ jump :: forall ref x a r.
      -> Sem r a
 
 -----------------------------------------------------------------------------
--- Reifies the current continuation in the form of a prompt, and passes it to
+-- | Reifies the current continuation in the form of a prompt, and passes it to
 -- the first argument. If the prompt becomes invoked via 'jump', then the
 -- second argument will be run before the reified continuation, and otherwise
 -- will not be called at all.

--- a/src/Polysemy/Final.hs
+++ b/src/Polysemy/Final.hs
@@ -73,8 +73,10 @@ makeSem_ ''Final
 
 -----------------------------------------------------------------------------
 -- | Allows for embedding higher-order actions of the final monad
--- by providing the means of explicitly threading effects through 'Sem r'
--- to the final monad. Consider using 'withStrategic' instead,
+-- by providing the means of explicitly threading effects through @'Sem' r@
+-- to the final monad.
+--
+-- Consider using 'withStrategic' instead,
 -- as it provides a more user-friendly interface to the same power.
 --
 -- You are discouraged from using 'withWeaving' directly in application code,
@@ -255,9 +257,9 @@ runFinal = usingSem $ \u -> case decomp u of
 -- constraint, as long as @m@ can be transformed to the final monad;
 -- but be warned, this breaks the implicit contract of @'LastMember' ('Lift' m)@
 -- that @m@ /is/ the final monad, so depending on the final monad and operations
--- used, 'runFinalTrans' may become /unsafe/.
+-- used, 'runFinalLift' may become /unsafe/.
 --
--- For example, 'runFinalTrans' is unsafe with 'runAsync' if
+-- For example, 'runFinalLift' is unsafe with 'Polysemy.Async.runAsync' if
 -- the final monad is non-deterministic, or a continuation
 -- monad.
 runFinalLift :: Monad m

--- a/src/Polysemy/Shift.hs
+++ b/src/Polysemy/Shift.hs
@@ -1,0 +1,313 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Polysemy.Shift
+  (
+    module Polysemy.Cont
+    -- * Effect
+  , Shift(..)
+
+    -- * Actions
+  , trap
+  , invoke
+  , abort
+  , reset
+  , reset'
+  , shift
+
+    -- * Interpretations
+  , runShiftPure
+  , runShiftM
+  , runShiftFinal
+  , runShiftWithCPure
+  , runShiftWithCM
+
+  , runContShiftPure
+  , runContShiftM
+  , runContShiftWithCPure
+  , runContShiftWithCM
+
+    -- * Unsafe Interpretations
+  , runShiftUnsafe
+  , runShiftWithCUnsafe
+  , runContShiftUnsafe
+  , runContShiftWithCUnsafe
+  ) where
+
+
+import Polysemy
+import Polysemy.Cont
+import Polysemy.Cont.Internal
+import Polysemy.Shift.Internal
+import Polysemy.Final
+
+import Polysemy.Internal
+import Polysemy.Internal.Union
+
+import Control.Monad.Cont (ContT(..))
+
+-----------------------------------------------------------------------------
+-- | A variant of 'callCC'.
+-- Executing the provided continuation will not abort execution.
+--
+-- Higher-order effects do not interact with the continuation in any meaningful
+-- way; i.e. 'Polysemy.Reader.local' or 'Polysemy.Writer.censor' does not affect
+-- it, 'Polysemy.Error.catch' will fail to catch any of its exceptions,
+-- and 'Polysemy.Writer.listen' will always return 'mempty'.
+-- The only exception to this is if you interpret such effects /and/ 'Cont'
+-- in terms of the final monad, and the final monad can perform such interactions
+-- in a meaningful manner.
+--
+-- The provided continuation may fail locally in its subcontinuations.
+-- It may sometimes become necessary to handle such cases, in
+-- which case such failure may be detected by using 'reset\'' together
+-- with the provided continuation.
+shift :: Member (Shift ref s) r
+      => ((a -> Sem r s) -> Sem r s)
+      -> Sem r a
+shift cc = trap $ \ref -> cc (invoke ref)
+{-# INLINE shift #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Shift' effect by providing 'pure '.' Just' as the final
+-- continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+--
+-- This is a safe variant of 'runContUnsafe', as this may only be used
+-- as the final interpreter before 'run'.
+runShiftPure :: Sem '[Shift (Ref (Sem '[]) (Maybe a)) a] a
+             -> Sem '[] (Maybe a)
+runShiftPure = runShiftUnsafe
+{-# INLINE runShiftPure #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Shift' effect by providing 'pure '.' Just' as the final
+-- continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+--
+-- This is a safe variant of 'runContUnsafe', as this may only be used
+-- as the final interpreter before 'run'.
+runShiftM :: Sem '[Shift (Ref (Sem '[Lift m]) (Maybe a)) a, Lift m] a
+          -> Sem '[Lift m] (Maybe a)
+runShiftM = runShiftUnsafe
+{-# INLINE runShiftM #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Shift' effect in terms of a final 'ContT'
+--
+-- /Beware/: Effects that aren't interpreted in terms of the final monad
+-- will have local state semantics in regards to 'Shift' effects
+-- interpreted this way. See 'interpretFinal'.
+runShiftFinal :: forall s m a r
+              .  (Member (Final (ContT (Maybe s) m)) r, Monad m)
+              => Sem (Shift (Ref m (Maybe s)) s ': r) a
+              -> Sem r a
+runShiftFinal = interpretFinal $ \case
+  Trap main -> do
+    main'         <- bindS main
+    s             <- getInitialStateS
+    Inspector ins <- getInspectorS
+    pure $ ContT $ \c ->
+      runContT (main' (Ref (c . (<$ s)) <$ s)) (pure . ins)
+  Invoke ref a -> liftS $ ContT $ \c -> runRef ref a >>= maybe (pure Nothing) c
+  Abort s -> pure $ ContT $ \_ -> pure (Just s)
+  Reset main -> do
+    main'         <- runS main
+    Inspector ins <- getInspectorS
+    liftS $ ContT $ \c ->
+      runContT main' (pure . ins) >>= maybe (pure Nothing) c
+  Reset' main -> do
+    main'         <- runS main
+    Inspector ins <- getInspectorS
+    liftS $ ContT $ \c ->
+      runContT main' (pure . ins) >>= c
+{-# INLINE runShiftFinal #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Shift' effect by explicitly providing a final
+-- continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+--
+-- This is a safe variant of 'runShiftWithCUnsafe', as this may only be used
+-- as the final interpreter before 'run'.
+runShiftWithCPure :: (a -> Sem '[] (Maybe b))
+                  -> Sem '[Shift (Ref (Sem '[]) (Maybe b)) b] a
+                  -> Sem '[] (Maybe b)
+runShiftWithCPure = runShiftWithCUnsafe
+{-# INLINE runShiftWithCPure #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Shift' effect by explicitly providing a final
+-- continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+--
+-- This is a safe variant of 'runShiftWithCUnsafe', as this may only be used
+-- as the final interpreter before 'runM'.
+runShiftWithCM :: (a -> Sem '[Lift m] (Maybe b))
+               -> Sem '[Shift (Ref (Sem '[Lift m]) (Maybe b)) b, Lift m] a
+               -> Sem '[Lift m] (Maybe b)
+runShiftWithCM = runShiftWithCUnsafe
+{-# INLINE runShiftWithCM #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Cont' and a 'Shift' effect simultaneously by providing
+-- @'pure' '.' 'Just'@ as the final continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+--
+-- This is a safe variant of 'runContShiftUnsafe', as this may only be used
+-- as the final interpreter before 'run'.
+runContShiftPure :: Sem [ Cont (Ref (Sem '[]) (Maybe a))
+                        , Shift (Ref (Sem '[]) (Maybe a)) a
+                        ] a
+                 -> Sem '[] (Maybe a)
+runContShiftPure = runContShiftUnsafe
+{-# INLINE runContShiftPure #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Cont' and a 'Shift' effect simultaneously by providing
+-- @'pure' '.' 'Just'@ as the final continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+--
+-- This is a safe variant of 'runContShiftUnsafe', as this may only be used
+-- as the final interpreter before 'runM'.
+runContShiftM :: Sem [ Cont (Ref (Sem '[Lift m]) (Maybe a))
+                     , Shift (Ref (Sem '[Lift m]) (Maybe a)) a
+                     , Lift m
+                     ] a
+              -> Sem '[Lift m] (Maybe a)
+runContShiftM = runContShiftUnsafe
+{-# INLINE runContShiftM #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Cont' and a 'Shift' effect simultaneously by explicitly providing
+-- a final continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+--
+-- This is a safe variant of 'runContShiftWithCUnsafe', as this may only be
+-- used as the final interpreter before 'run'.
+runContShiftWithCPure :: (a -> Sem '[] (Maybe s))
+                      -> Sem [ Cont (Ref (Sem '[]) (Maybe s))
+                             , Shift (Ref (Sem '[]) (Maybe s)) s
+                             ] a
+                      -> Sem '[] (Maybe s)
+runContShiftWithCPure = runContShiftWithCUnsafe
+{-# INLINE runContShiftWithCPure #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Cont' and a 'Shift' effect simultaneously by explicitly providing
+-- a final continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+--
+-- This is a safe variant of 'runContShiftWithCUnsafe', as this may only be used
+-- as the final interpreter before 'runM'.
+runContShiftWithCM :: (a -> Sem '[Lift m] (Maybe s))
+                   -> Sem [ Cont (Ref (Sem '[Lift m]) (Maybe s))
+                          , Shift (Ref (Sem '[Lift m]) (Maybe s)) s
+                          , Lift m
+                          ] a
+                   -> Sem '[Lift m] (Maybe s)
+runContShiftWithCM = runContShiftWithCUnsafe
+{-# INLINE runContShiftWithCM #-}
+
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Shift' effect by providing @'pure' '.' 'Just'@
+-- as the final continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+--
+-- __Beware__: This interpreter will invalidate all higher-order effects of any
+-- interpreter run after it; i.e. 'Polysemy.Reader.local' and
+-- 'Polysemy.Writer.censor' will be no-ops, 'Polysemy.Error.catch' will fail
+-- to catch exceptions, and 'Polysemy.Writer.listen' will always return 'mempty'.
+--
+-- __You should therefore use 'runShift' /after/ running all interpreters for
+-- your higher-order effects.__
+runShiftUnsafe :: Sem (Shift (Ref (Sem r) (Maybe a)) a ': r) a -> Sem r (Maybe a)
+runShiftUnsafe = runShiftWithCUnsafe (pure . Just)
+{-# INLINE runShiftUnsafe #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Shift' effect by explicitly providing a final continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that any
+-- continuation may fail locally.
+--
+-- __Beware__: This interpreter will invalidate all higher-order effects of any
+-- interpreter run after it; i.e. 'Polysemy.Reader.local' and
+-- 'Polysemy.Writer.censor' will be no-ops, 'Polysemy.Error.catch' will fail
+-- to catch exceptions, and 'Polysemy.Writer.listen' will always return 'mempty'.
+--
+-- __You should therefore use 'runShiftWithC' /after/ running all interpreters for
+-- your higher-order effects.__
+runShiftWithCUnsafe :: forall s a r.
+                       (a -> Sem r (Maybe s))
+                    -> Sem (Shift (Ref (Sem r) (Maybe s)) s ': r) a
+                    -> Sem r (Maybe s)
+runShiftWithCUnsafe c (Sem sem) = (`runContT` c) $ sem $ \u -> case decomp u of
+  Right weaving -> runShiftWeaving runShiftWithCUnsafe weaving
+  Left g -> ContT $ \c' -> embedSem g >>= runShiftWithCUnsafe c'
+{-# INLINE runShiftWithCUnsafe #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Cont' and a 'Shift' effect simultaneously by providing
+-- @'pure' '.' 'Just'@ as the final continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+--
+-- __Beware__: This interpreter will invalidate all higher-order effects of any
+-- interpreter run after it; i.e. 'Polysemy.Reader.local' and
+-- 'Polysemy.Writer.censor' will be no-ops, 'Polysemy.Error.catch' will fail
+-- to catch exceptions, and 'Polysemy.Writer.listen' will always return 'mempty'.
+--
+-- __You should therefore use 'runShift' /after/ running all interpreters for
+-- your higher-order effects.__
+runContShiftUnsafe :: Sem (   Cont (Ref (Sem r) (Maybe a))
+                           ': Shift (Ref (Sem r) (Maybe a)) a
+                           ': r) a
+                   -> Sem r (Maybe a)
+runContShiftUnsafe = runContShiftWithCUnsafe (pure . Just)
+{-# INLINE runContShiftUnsafe #-}
+
+-----------------------------------------------------------------------------
+-- | Runs a 'Cont' and a 'Shift' effect simultaneously by explicitly providing
+-- a final continuation.
+--
+-- The final return type is wrapped in a 'Maybe' due to the fact that
+-- any continuation may fail locally.
+--
+-- __Beware__: This interpreter will invalidate all higher-order effects of any
+-- interpreter run after it; i.e. 'Polysemy.Reader.local' and
+-- 'Polysemy.Writer.censor' will be no-ops, 'Polysemy.Error.catch' will fail
+-- to catch exceptions, and 'Polysemy.Writer.listen' will always return 'mempty'.
+--
+-- __You should therefore use 'runShift' /after/ running all interpreters for
+-- your higher-order effects.__
+runContShiftWithCUnsafe :: forall s a r.
+                           (a -> Sem r (Maybe s))
+                        -> Sem (   Cont (Ref (Sem r) (Maybe s))
+                                ': Shift (Ref (Sem r) (Maybe s)) s
+                                ': r) a
+                        -> Sem r (Maybe s)
+runContShiftWithCUnsafe c (Sem m) = (`runContT` c) $ m $ \u -> case decomp u of
+  Right weaving -> runContWeaving runContShiftWithCUnsafe weaving
+  Left g -> case decomp g of
+    Right weaving -> runShiftWeaving runContShiftWithCUnsafe weaving
+    Left g'       -> ContT $ \c' -> embedSem g' >>= runContShiftWithCUnsafe c'
+{-# INLINE runContShiftWithCUnsafe #-}

--- a/src/Polysemy/Shift/Internal.hs
+++ b/src/Polysemy/Shift/Internal.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Polysemy.Shift.Internal where
+
+import Polysemy
+import Polysemy.Internal.Union
+import Polysemy.Cont.Internal (Ref(..))
+import Control.Monad.Cont (ContT(..))
+
+-----------------------------------------------------------------------------
+-- | An effect for delimited continuations, formulated algebraically
+-- through a variant of the 'Jump'/'Subst' formulation of abortive
+-- continuations.
+--
+-- Activating polysemy-plugin is highly recommended when using this effect
+-- in order to avoid ambiguous types.
+data Shift ref s m a where
+  Trap    :: (ref a -> m s) -> Shift ref s m a
+  Invoke  :: ref a -> a -> Shift ref s m s
+  Abort   :: s   -> Shift ref s m a
+  Reset   :: m s -> Shift ref s m s
+  Reset'  :: m s -> Shift ref s m (Maybe s)
+
+makeSem_ ''Shift
+
+-----------------------------------------------------------------------------
+-- Reifies the current continuation in the form of a prompt, and passes it to
+-- the first argument. Unlike 'subst', control will never return to the current
+-- continuation unless the prompt is invoked via 'release'.
+trap :: forall ref s a r
+     .  Member (Shift ref s) r
+     => (ref a -> Sem r s)
+     -> Sem r a
+
+-----------------------------------------------------------------------------
+-- Provide an answer to a prompt, jumping to its reified continuation.
+-- Unlike 'jump', this will not abort the current continuation, and the
+-- reified computation will instead return its final result when finished.
+--
+-- The provided continuation may fail locally in its subcontinuations.
+-- It may sometimes become necessary to handle such cases. To do so,
+-- use 'reset\'' together with 'release'.
+invoke :: forall ref a x r
+       .  Member (Shift ref a) r
+       => ref x
+       -> x
+       -> Sem r a
+
+
+-----------------------------------------------------------------------------
+-- | Aborts the current continuation with a result.
+abort :: forall ref s a r
+      .  Member (Shift ref s) r
+      => s
+      -> Sem r a
+
+-----------------------------------------------------------------------------
+-- Delimits any continuations and calls to 'abort'.
+reset :: forall ref a r
+      .  Member (Shift ref a) r
+      => Sem r a
+      -> Sem r a
+
+-----------------------------------------------------------------------------
+-- Delimits any continuations and calls to 'abort', and detects if
+-- any subcontinuation has failed locally.
+reset' :: forall ref s r
+       .  Member (Shift ref s) r
+       => Sem r s
+       -> Sem r (Maybe s)
+
+runShiftWeaving :: Monad m
+                => (forall x. (x -> m (Maybe s)) -> Sem r x -> m (Maybe s))
+                -> Weaving (Shift (Ref m (Maybe s)) s) (Sem r) a
+                -> ContT (Maybe s) m a
+runShiftWeaving runW (Weaving e s wv ex ins) =
+  fmap (ex . (<$ s)) $ ContT $ \c ->
+    case e of
+      Trap main ->
+        runW (pure . ins) $ wv (main (Ref c) <$ s)
+      Invoke ref a ->
+        runRef ref a >>= maybe (pure Nothing) c
+      Abort t -> pure (Just t)
+      Reset main ->
+        runW (pure . ins) (wv (main <$ s)) >>= maybe (pure Nothing) c
+      Reset' main ->
+        runW (pure . ins) (wv (main <$ s)) >>= c
+{-# INLINE runShiftWeaving #-}

--- a/src/Polysemy/Shift/Internal.hs
+++ b/src/Polysemy/Shift/Internal.hs
@@ -23,7 +23,7 @@ data Shift ref s m a where
 makeSem_ ''Shift
 
 -----------------------------------------------------------------------------
--- Reifies the current continuation in the form of a prompt, and passes it to
+-- | Reifies the current continuation in the form of a prompt, and passes it to
 -- the first argument. Unlike 'subst', control will never return to the current
 -- continuation unless the prompt is invoked via 'release'.
 trap :: forall ref s a r
@@ -32,9 +32,19 @@ trap :: forall ref s a r
      -> Sem r a
 
 -----------------------------------------------------------------------------
--- Provide an answer to a prompt, jumping to its reified continuation.
+-- | Provide an answer to a prompt, jumping to its reified continuation.
 -- Unlike 'jump', this will not abort the current continuation, and the
 -- reified computation will instead return its final result when finished.
+--
+-- Any effectful state of effects which have been run before the interpreter for
+-- 'Shift' will be embedded in the return value, and therefore the invocation
+-- won't have any apparent effects unless these are interpreted in the final
+-- monad.
+--
+-- Any higher-order actions will also not interact with the continuation in any
+-- meaningful way; i.e. 'Polysemy.Reader.local' or 'Polysemy.Writer.censor' does
+-- not affect it, 'Polysemy.Error.catch' will fail to catch any of its exceptions,
+-- and 'Polysemy.Writer.listen' will always return 'mempty'.
 --
 -- The provided continuation may fail locally in its subcontinuations.
 -- It may sometimes become necessary to handle such cases. To do so,
@@ -54,14 +64,14 @@ abort :: forall ref s a r
       -> Sem r a
 
 -----------------------------------------------------------------------------
--- Delimits any continuations and calls to 'abort'.
+-- | Delimits any continuations and calls to 'abort'.
 reset :: forall ref a r
       .  Member (Shift ref a) r
       => Sem r a
       -> Sem r a
 
 -----------------------------------------------------------------------------
--- Delimits any continuations and calls to 'abort', and detects if
+-- | Delimits any continuations and calls to 'abort', and detects if
 -- any subcontinuation has failed locally.
 reset' :: forall ref s r
        .  Member (Shift ref s) r

--- a/test/CaptureSpec.hs
+++ b/test/CaptureSpec.hs
@@ -1,0 +1,115 @@
+module CaptureSpec where
+
+import Test.Hspec
+
+import Polysemy
+import Polysemy.Capture
+import Polysemy.Writer
+import Polysemy.Reader
+import Polysemy.Error
+
+test1 :: (String, Maybe ())
+test1 =
+    run
+  . runReader (1 :: Int)
+  . runWriter
+  . runCapture
+  $ do
+  capture $ \c -> do
+    _ <- local (+1) (c ())
+    _ <- censor (show . (+2) . (read :: String -> Int)) (c ())
+    tell "important"
+    local (+3) (c ())
+  j <- ask
+  tell (show j)
+
+test2 :: (String, Maybe ())
+test2 =
+    run
+  . runReader (1 :: Int)
+  . runWriter
+  . runCapture
+  $ do
+  delimit $ capture $ \c -> do
+    _ <- local (+1) (c ())
+    _ <- local (+2) (c ())
+    tell "important"
+    local (+3) (c ())
+  j <- ask
+  tell (show j)
+
+test3 :: (String, Maybe ())
+test3 =
+    run
+  . runReader (1 :: Int)
+  . runWriter
+  . runCapture
+  $ do
+  censor (++"!") $ capture $ \c -> do
+    _ <- local (+1) (c ())
+    _ <- local (+2) (c ())
+    tell "important"
+    local (+3) (c ())
+  j <- ask
+  tell (show j)
+
+test4 :: Maybe (String, ())
+test4 =
+    run
+  . runReader (1 :: Int)
+  . runCapture
+  . runWriter
+  $ do
+  capture $ \c -> do
+    _ <- local (+1) (c ())
+    _ <- local (+2) (c ())
+    tell "important"
+    local (+3) (c ())
+  j <- ask
+  tell (show j)
+
+test5 :: Maybe (Either () ())
+test5 =
+    run
+  . runCapture
+  . runError
+  $ do
+  capture $ \_ -> do
+    throw ()
+
+test6 :: Maybe (Either () ())
+test6 =
+    run
+  . runCapture
+  . runError
+  $ do
+  r <- delimit' $ capture $ \_ -> do
+    throw ()
+  case r of
+    Just g -> return g
+    _      -> return ()
+
+spec :: Spec
+spec = do
+  describe "runCapture" $ do
+    it "should have global state semantics, and\
+     \ have higher-order effects affect continuations" $
+      test1 `shouldBe` ("23important4", Just ())
+
+    it "should have global state semantics, but\
+     \ 'delimit' should delimit the continuation." $
+      test2 `shouldBe` ("important1", Just ())
+
+    it "should have global state semantics, and\
+        \ 'censor' should delimit the continuation" $
+      test3 `shouldBe` ("important!1", Just ())
+
+    it "should treat writer with local state semantics, but \
+       \ reader with global state semantics." $
+      test4 `shouldBe` Just ("4", ())
+
+    it "should fail from failing locally" $
+      test5 `shouldBe` Nothing
+
+    it "should recover from failing locally" $
+      test6 `shouldBe` Just (Right ())

--- a/test/CaptureSpec.hs
+++ b/test/CaptureSpec.hs
@@ -104,7 +104,7 @@ spec = do
         \ 'censor' should delimit the continuation" $
       test3 `shouldBe` ("important!1", Just ())
 
-    it "should treat writer with local state semantics, but \
+    it "should treat writer with local state semantics, but\
        \ reader with global state semantics." $
       test4 `shouldBe` Just ("4", ())
 

--- a/test/ContSpec.hs
+++ b/test/ContSpec.hs
@@ -1,0 +1,154 @@
+module ContSpec where
+
+import Test.Hspec
+
+import Data.IORef
+
+import Polysemy
+import Polysemy.Cont
+import Polysemy.Error
+import Polysemy.Reader
+import Polysemy.Writer
+import Polysemy.State
+import Polysemy.Trace
+import Polysemy.Final.MTL
+
+import qualified Control.Monad.State as S
+import qualified Control.Monad.Cont as C
+
+test1 :: (String, Int)
+test1 =
+    run
+  . runContPure
+  . runReader 1
+  . runWriter
+  $ do
+  i <- censor (++"!") $ local (+1) $ callCC $ \c -> do
+    i <- local (+1) ask
+    tell "unimportant"
+    local (+1) (c i)
+  tell (show i)
+  j <- ask
+  return j
+
+test2 :: (String, ())
+test2 =
+    run
+  . runContPure
+  . runReader (1 :: Int)
+  . runWriter
+  $ do
+  i <- censor (++"!") $ local (+1) $ callCC $ \_ -> do
+    i <- local (+1) ask
+    tell "important"
+    return i
+  tell (show i)
+  return ()
+
+test3 :: Either () ()
+test3 =
+     run
+   . runContPure
+   . runError
+   $ catch (callCC $ \_ -> throw ()) (\_ -> pure ())
+
+stateTest :: (Member (State Int) r, Member (Cont ref) r)
+          => Sem r Int
+stateTest = do
+  i <- get
+  put (i + 1)
+  callCC $ \c -> do
+    j <- get
+    put (j + 1)
+    c ()
+  get
+
+test4 :: (Int, Int)
+test4 =
+    (`S.runState` 1)
+  . runM
+  . runContM
+  . runStateFinal
+  $ stateTest
+
+test5 :: IO (Int, Int)
+test5 = do
+  ref <- newIORef 1
+
+  r <-  runM
+      . runContM
+      . runStateInIORef ref
+      $ stateTest
+  s' <- readIORef ref
+  return (r, s')
+
+test6 :: (Int, Int)
+test6 =
+    run
+  . runState 1
+  . runContUnsafe
+  $ stateTest
+
+test7 :: ([String], String)
+test7 =
+    (`C.runCont` id)
+  . runFinal
+  . runTraceAsList
+  . runReader ""
+  . runContFinal
+  $ do
+  j <- local (++".") $ callCC $ \c -> do
+    j <- ask
+    trace "Global state semantics?"
+    local (\_ -> "What's that?") (c j)
+  i <- local (++"Nothing") ask
+  trace $ i
+  callCC $ \_ ->
+    trace "at"
+  trace "all."
+  return j
+
+test8 :: Int
+test8 =
+     ($ 1)
+   . (`C.runContT` pure)
+   . runFinal
+   . runReaderFinal
+   . runContFinal
+   $ do
+  callCC $ \c ->
+    local (+1) (c ())
+  ask
+
+spec :: Spec
+spec = do
+  describe "runContPure" $ do
+    it "should work with higher-order effects if not applied on continuations\
+          \ and discard local state" $
+      test1 `shouldBe` ("!3", 1)
+
+    it "should not discard local state if continuation is never invoked" $
+      test2 `shouldBe` ("important!3", ())
+
+    it "should catch exception within callCC" $
+      test3 `shouldBe` Right ()
+
+  describe "runContM" $ do
+    it "should have global state semantics with runStateFinal" $
+      test4 `shouldBe` (3, 3)
+
+    it "should have global state semantics with runStateInIORef" $ do
+      r <- test5
+      r `shouldBe` (3, 3)
+
+  describe "runContFinal" $ do
+    it "should work just like runContPure/M." $
+      test7 `shouldBe` (["Nothing", "at", "all."], ".")
+
+    it "should be able to apply local to continuation" $
+      test8 `shouldBe` 2
+
+  describe "runContUnsafe" $ do
+    it "should work with and have global state semantics with runState\
+       \ run after it" $
+      test6 `shouldBe` (3, 3)

--- a/test/ShiftSpec.hs
+++ b/test/ShiftSpec.hs
@@ -1,0 +1,126 @@
+module ShiftSpec where
+
+import Test.Hspec
+
+import Data.IORef
+
+import Polysemy
+import Polysemy.Shift
+import Polysemy.Error
+import Polysemy.Reader
+import Polysemy.Writer
+import Polysemy.State
+import Polysemy.Final.MTL
+
+import Control.Monad.Cont(ContT(..))
+import Control.Monad.State(StateT(..))
+
+
+test1 :: Maybe (String, ())
+test1 =
+    run
+  . runShiftPure
+  . runReader (1 :: Int)
+  . runWriter
+  $ do
+  censor (++"!") $ shift $ \c -> do
+    _ <- local (+1) (c ())
+    _ <- local (+1) (c ())
+    tell "unimportant"
+    local (+1) (c ())
+  j <- ask
+  tell (show j)
+
+test2 :: Maybe (Either () ())
+test2 =
+    run
+  . runShiftPure
+  . runError
+  $ do
+  shift $ \_ -> do
+    throw ()
+
+test3 :: Maybe (Either () ())
+test3 =
+    run
+  . runShiftPure
+  . runError
+  $ do
+  r <- reset' $ shift $ \_ -> do
+    throw ()
+  case r of
+    Just r' -> abort r'
+    _       -> pure ()
+
+test4 :: IO (Maybe Int)
+test4 = do
+  ref <- newIORef 1
+  runM
+   . runShiftM
+   . runStateInIORef ref
+   $ do
+    shift $ \c -> do
+      _ <- c ()
+      _ <- c ()
+      c ()
+    modify (+1)
+    get
+
+test5 :: (Maybe Int, Int)
+test5 =
+    ($ 1)
+  . (`runStateT` 1)
+  . (`runContT` (pure . Just))
+  . runFinal
+  . runStateFinal
+  . runShiftFinal
+  . runReaderFinal
+  $ do
+  shift $ \c -> do
+    _ <- local (+1) (c ())
+    _ <- local (+2) (c ())
+    local (+3) (c ())
+  i <- ask
+  modify (+i)
+  get
+
+test6 :: (Int, Maybe Int)
+test6 =
+     run
+   . runState 1
+   . runShiftUnsafe
+   $ do
+    shift $ \c -> do
+      _ <- c ()
+      _ <- c ()
+      c ()
+    modify (+1)
+    get
+
+spec :: Spec
+spec = do
+  describe "runShiftPure" $ do
+    it "should only tell once, censor once, and\
+       \ local should have no effect on the continuation." $
+      test1 `shouldBe` Just ("!1", ())
+
+    it "should fail from failing locally" $ do
+      test2 `shouldBe` Nothing
+
+    it "should recover from failing locally" $ do
+      test3 `shouldBe` Just (Right ())
+
+  describe "runShiftM" $ do
+    it "should modify multiple times with runStateInIORef" $ do
+      res <- test4
+      res `shouldBe` Just 4
+
+  describe "runShiftFinal" $ do
+    it "should modify multiple times with runStateFinal\
+        \ and should be able to apply local to continuation" $
+      test5 `shouldBe` (Just 10, 10)
+
+  describe "runShiftUnsafe" $ do
+    it "should modify multiple times with runState\
+        \ runState run after it" $
+      test6 `shouldBe` (4, Just 4)

--- a/test/ShiftSpec.hs
+++ b/test/ShiftSpec.hs
@@ -122,5 +122,5 @@ spec = do
 
   describe "runShiftUnsafe" $ do
     it "should modify multiple times with runState\
-        \ runState run after it" $
+        \ run after it" $
       test6 `shouldBe` (4, Just 4)


### PR DESCRIPTION
This adds the effects `Cont` and `Shift`, for abortive and delimited continuations respectively.

These effects work by being parametrized by `s` and `m`, where `s` is the final result type, and `m` is the final monad type.
Polymorphic code with these effects are intended to be polymorphic in `m`, and may choose to be polymorphic in `s`. This way, you can get the traditional `callCC`/`shift`/`reset` operations. If you specialize `s`, you also get access to `abort`, which lets you end a computation early.

Unfortunately, the interpreters for these are wonky. The only way to transform
 `Union r (Sem (Cont s m ': r)) x`  to `Sem r x` is to "replace" any higher-order use of values of type `Sem (Cont s m ': r)` within the union with a _pure_ value of `Sem r`. The effect of this is that any continuation you get with `callCC`/`shift` is unaffected by higher-order operations such as `local` and `censor`, and `listen` on a continuation will just return `mempty`.

Still, it's pretty neat that this is at all even possible, considering `ContT` is not a functor on monads.