### PR TITLE
Update to polysemy's new names

### DIFF
--- a/src/Polysemy/Capture.hs
+++ b/src/Polysemy/Capture.hs
@@ -43,15 +43,15 @@ data Capture ref m a where
   Delimit  :: m a -> Capture ref m a
   Delimit' :: m a -> Capture ref m (Maybe a)
 
-makeSem_ ''Capture
+makeSem ''Capture
 
 -----------------------------------------------------------------------------
 -- | Reifies the current continuation in the form of a prompt, and passes it to
 -- the first argument.
-reify :: forall ref a r
-      .  Member (Capture ref) r
-      => (forall s. ref s a -> Sem r s)
-      -> Sem r a
+-- reify :: forall ref a r
+--       .  Member (Capture ref) r
+--       => (forall s. ref s a -> Sem r s)
+--       -> Sem r a
 
 -----------------------------------------------------------------------------
 -- | Provide an answer to a prompt, jumping to its reified continuation.
@@ -62,26 +62,26 @@ reify :: forall ref a r
 -- It may sometimes become necessary to handle such cases. To do so,
 -- use 'delimit\'' together with 'reflect' (the reified continuation
 -- is already delimited).
-reflect :: forall ref a x r
-        .  Member (Capture ref) r
-        => ref a x
-        -> x
-        -> Sem r a
+-- reflect :: forall ref a x r
+--         .  Member (Capture ref) r
+--         => ref a x
+--         -> x
+--         -> Sem r a
 
 -----------------------------------------------------------------------------
 -- | Delimits any continuations
-delimit :: forall ref a r
-        .  Member (Capture ref) r
-        => Sem r a
-        -> Sem r a
+-- delimit :: forall ref a r
+--         .  Member (Capture ref) r
+--         => Sem r a
+--         -> Sem r a
 
 -----------------------------------------------------------------------------
 -- | Delimits any continuations, and detects if any subcontinuation
 -- has failed locally.
-delimit' :: forall ref a r
-         .  Member (Capture ref) r
-         => Sem r a
-         -> Sem r (Maybe a)
+-- delimit' :: forall ref a r
+--          .  Member (Capture ref) r
+--          => Sem r a
+--          -> Sem r (Maybe a)
 
 -----------------------------------------------------------------------------
 -- | A restricted version of 'Polysemy.Shift.shift'.

--- a/src/Polysemy/Cont.hs
+++ b/src/Polysemy/Cont.hs
@@ -68,7 +68,7 @@ runContPure = runContUnsafe
 --
 -- This is a safe variant of 'runContUnsafe', as this may only be used
 -- as the final interpreter before 'runM'.
-runContM :: Sem '[Cont (Ref (Sem '[Lift m]) a), Lift m] a -> Sem '[Lift m] a
+runContM :: Sem '[Cont (Ref (Sem '[Embed m]) a), Embed m] a -> Sem '[Embed m] a
 runContM = runContUnsafe
 {-# INLINE runContM #-}
 

--- a/src/Polysemy/Cont/Internal.hs
+++ b/src/Polysemy/Cont/Internal.hs
@@ -16,7 +16,7 @@ data Cont ref m a where
   Jump    :: ref a -> a -> Cont ref m b
   Subst   :: (ref a -> m b) -> (a -> m b) -> Cont ref m b
 
-makeSem_ ''Cont
+makeSem ''Cont
 
 -----------------------------------------------------------------------------
 -- | Provide an answer to a prompt, jumping to its reified continuation,
@@ -34,22 +34,22 @@ makeSem_ ''Cont
 -- The only exception to this is if you interpret such effects /and/ 'Cont'
 -- in terms of the final monad, and the final monad can perform such interactions
 -- in a meaningful manner.
-jump :: forall ref x a r.
-        Member (Cont ref) r
-     => ref x
-     -> x
-     -> Sem r a
+-- jump :: forall ref x a r.
+--         Member (Cont ref) r
+--      => ref x
+--      -> x
+--      -> Sem r a
 
 -----------------------------------------------------------------------------
 -- | Reifies the current continuation in the form of a prompt, and passes it to
 -- the first argument. If the prompt becomes invoked via 'jump', then the
 -- second argument will be run before the reified continuation, and otherwise
 -- will not be called at all.
-subst :: forall ref x a r.
-         Member (Cont ref) r
-      => (ref x -> Sem r a)
-      -> (x -> Sem r a)
-      -> Sem r a
+-- subst :: forall ref x a r.
+--          Member (Cont ref) r
+--       => (ref x -> Sem r a)
+--       -> (x -> Sem r a)
+--       -> Sem r a
 
 -----------------------------------------------------------------------------
 -- | Runs a 'Cont' effect by providing a final continuation.

--- a/src/Polysemy/Final/Async.hs
+++ b/src/Polysemy/Final/Async.hs
@@ -14,18 +14,18 @@ import Polysemy.Final
 ------------------------------------------------------------------------------
 -- | Run an 'Async' effect through final 'IO'
 --
--- This can be used as an alternative to 'runAsyncInIO'.
+-- This can be used as an alternative to 'lowerAsync'.
 --
 -- /Beware/: Effects that aren't interpreted in terms of 'IO'
 -- will have local state semantics in regards to 'Async' effects
 -- interpreted this way. See 'interpretFinal'.
 --
--- Notably, unlike 'runAsync', this is not consistent with
+-- Notably, unlike 'asyncToIO', this is not consistent with
 -- 'Polysemy.State.State' unless 'Polysemy.State.runStateInIORef' is used.
 -- State that seems like it should be threaded globally throughout the `Async`
 -- /will not be./
 --
--- Prefer 'runAsync' unless its unsafe or inefficient in the context of your
+-- Prefer 'asyncToIO' unless its unsafe or inefficient in the context of your
 -- application.
 runAsyncFinal :: Member (Final IO) r
               => Sem (Async ': r) a

--- a/src/Polysemy/Final/MTL.hs
+++ b/src/Polysemy/Final/MTL.hs
@@ -64,12 +64,12 @@ runReaderFinal = interpretFinal $ \case
 -- /Beware/: Effects that aren't interpreted in terms of the final
 -- monad will have local state semantics in regards to 'State' effects
 -- interpreted this way. See 'interpretFinal'.
-runStateFinal :: (Member (Lift m) r, MonadState s m)
+runStateFinal :: (Member (Embed m) r, MonadState s m)
                => Sem (State s ': r) a
                -> Sem r a
 runStateFinal = interpret $ \case
-  Get   -> sendM get
-  Put s -> sendM (put s)
+  Get   -> embed get
+  Put s -> embed (put s)
 {-# INLINE runStateFinal #-}
 
 -----------------------------------------------------------------------------

--- a/src/Polysemy/IdempotentLowering.hs
+++ b/src/Polysemy/IdempotentLowering.hs
@@ -96,7 +96,7 @@ infixl 8 .@!
 
 ------------------------------------------------------------------------------
 -- | Like '.@!', but for interpreters which change the resulting type --- eg.
--- 'Polysemy.Error.runErrorInIO'.
+-- 'Polysemy.Error.lowerError.
 --
 -- @since 0.1.1.0
 (.@@!)

--- a/src/Polysemy/KVStore.hs
+++ b/src/Polysemy/KVStore.hs
@@ -107,7 +107,7 @@ runKVStorePurely m = runState m . runKVStoreAsState
 
 
 runKVStoreInRedis
-    :: ( Member (Lift R.Redis) r
+    :: ( Member (Embed R.Redis) r
        , Member (Error R.Reply) r
        , Binary k
        , Binary v

--- a/src/Polysemy/Operators.hs
+++ b/src/Polysemy/Operators.hs
@@ -3,7 +3,7 @@
 -- interpreters in more concise way, without mentioning unnecessary details:
 --
 -- @
--- foo :: 'Member' ('Lift' 'IO') r => 'String' -> 'Int' -> 'Sem' r ()
+-- foo :: 'Member' ('Embed' 'IO') r => 'String' -> 'Int' -> 'Sem' r ()
 -- @
 --
 -- can be written simply as:
@@ -27,7 +27,7 @@
 --
 -- 'makeSem' ''ConsoleIO
 --
--- -- runConsoleIO :: Member (Lift IO) r => Sem (ConsoleIO : r) a -> Sem r a
+-- -- runConsoleIO :: Member (Embed IO) r => Sem (ConsoleIO : r) a -> Sem r a
 -- runConsoleIO :: ConsoleIO : r '@>' a -> 'IO' '~@' r '@>' a
 -- runConsoleIO = 'interpret' \\case
 --   WriteStrLn s -> 'sendM' '$' 'putStrLn' s
@@ -64,7 +64,7 @@
 -- constraint instead:
 --
 -- @
--- foo :: 'Member' ('Lift' 'IO') r
+-- foo :: 'Member' ('Embed' 'IO') r
 --     => (forall x. r '@>' x -> 'IO' x)
 --     -> 'IO' (forall a. Foo : r '@>' a -> r '@>' a)
 -- @
@@ -143,7 +143,7 @@ type family SemList s where
 -- 'Sem' with __exactly__ one, lifted monad:
 --
 -- @
--- foo :: 'Sem' \'['Lift' 'IO'] ()
+-- foo :: 'Sem' \'['Embed' 'IO'] ()
 -- @
 --
 -- can be written simply as:
@@ -157,7 +157,7 @@ infix 2 @>, @-, @~
 
 type (@>)   = Sem
 type (@-) e = Sem '[e]
-type (@~) m = Sem '[Lift m]
+type (@~) m = Sem '[Embed m]
 
 -- $MemberOperators
 -- Infix equivalents of 'Member'(s) constraint used directly in /return/ type,
@@ -201,7 +201,7 @@ type (@~) m = Sem '[Lift m]
 -- __Exactly__ one, lifted monad as a member:
 --
 -- @
--- foo :: 'Member' ('Lift' 'IO') r => 'Sem' ('Polysemy.Output.Output' ['String'] : r) () -> 'Sem' r ()
+-- foo :: 'Member' ('Embed' 'IO') r => 'Sem' ('Polysemy.Output.Output' ['String'] : r) () -> 'Sem' r ()
 -- @
 --
 -- can be written simply as:
@@ -213,7 +213,7 @@ infix 1 >@, -@, ~@
 
 type (>@) es s = Members es       (SemList s) => s
 type (-@) e  s = Member  e        (SemList s) => s
-type (~@) m  s = Member  (Lift m) (SemList s) => s
+type (~@) m  s = Member  (Embed m) (SemList s) => s
 
 -- $CombinedOperators
 -- Joined versions of one of ('>@'), ('-@'), ('~@') and ('@>') with implicit,
@@ -255,7 +255,7 @@ type (~@) m  s = Member  (Lift m) (SemList s) => s
 -- __Exactly__ one, lifted monad as a member:
 --
 -- @
--- foo :: 'Member' ('Lift' 'IO') r => 'Sem' r ()
+-- foo :: 'Member' ('Embed' 'IO') r => 'Sem' r ()
 -- @
 --
 -- can be written simply as:
@@ -267,4 +267,4 @@ infix 1 >@>, -@>, ~@>
 
 type (>@>) es a = forall r. Members es       r => Sem r a
 type (-@>) e  a = forall r. Member  e        r => Sem r a
-type (~@>) m  a = forall r. Member  (Lift m) r => Sem r a
+type (~@>) m  a = forall r. Member  (Embed m) r => Sem r a

--- a/src/Polysemy/Random.hs
+++ b/src/Polysemy/Random.hs
@@ -49,9 +49,9 @@ runRandom q = runState q . reinterpret (\case
 
 ------------------------------------------------------------------------------
 -- | Run a 'Random' effect by using the 'IO' random generator.
-runRandomIO :: Member (Lift IO) r => Sem (Random ': r) a -> Sem r a
+runRandomIO :: Member (Embed IO) r => Sem (Random ': r) a -> Sem r a
 runRandomIO m = do
-  q <- sendM R.newStdGen
+  q <- embed R.newStdGen
   snd <$> runRandom q m
 {-# INLINE runRandomIO #-}
 

--- a/src/Polysemy/SetStore.hs
+++ b/src/Polysemy/SetStore.hs
@@ -42,7 +42,7 @@ runSetStoreAsKVStore = interpret $ \case
 
 
 runSetStoreInRedis
-    :: ( Member (Lift R.Redis) r
+    :: ( Member (Embed R.Redis) r
        , Member (Error R.Reply) r
        , Binary k
        , Binary v

--- a/src/Polysemy/Shift.hs
+++ b/src/Polysemy/Shift.hs
@@ -91,8 +91,8 @@ runShiftPure = runShiftUnsafe
 --
 -- This is a safe variant of 'runContUnsafe', as this may only be used
 -- as the final interpreter before 'run'.
-runShiftM :: Sem '[Shift (Ref (Sem '[Lift m]) (Maybe a)) a, Lift m] a
-          -> Sem '[Lift m] (Maybe a)
+runShiftM :: Sem '[Shift (Ref (Sem '[Embed m]) (Maybe a)) a, Embed m] a
+          -> Sem '[Embed m] (Maybe a)
 runShiftM = runShiftUnsafe
 {-# INLINE runShiftM #-}
 
@@ -151,9 +151,9 @@ runShiftWithCPure = runShiftWithCUnsafe
 --
 -- This is a safe variant of 'runShiftWithCUnsafe', as this may only be used
 -- as the final interpreter before 'runM'.
-runShiftWithCM :: (a -> Sem '[Lift m] (Maybe b))
-               -> Sem '[Shift (Ref (Sem '[Lift m]) (Maybe b)) b, Lift m] a
-               -> Sem '[Lift m] (Maybe b)
+runShiftWithCM :: (a -> Sem '[Embed m] (Maybe b))
+               -> Sem '[Shift (Ref (Sem '[Embed m]) (Maybe b)) b, Embed m] a
+               -> Sem '[Embed m] (Maybe b)
 runShiftWithCM = runShiftWithCUnsafe
 {-# INLINE runShiftWithCM #-}
 
@@ -182,11 +182,11 @@ runContShiftPure = runContShiftUnsafe
 --
 -- This is a safe variant of 'runContShiftUnsafe', as this may only be used
 -- as the final interpreter before 'runM'.
-runContShiftM :: Sem [ Cont (Ref (Sem '[Lift m]) (Maybe a))
-                     , Shift (Ref (Sem '[Lift m]) (Maybe a)) a
-                     , Lift m
+runContShiftM :: Sem [ Cont (Ref (Sem '[Embed m]) (Maybe a))
+                     , Shift (Ref (Sem '[Embed m]) (Maybe a)) a
+                     , Embed m
                      ] a
-              -> Sem '[Lift m] (Maybe a)
+              -> Sem '[Embed m] (Maybe a)
 runContShiftM = runContShiftUnsafe
 {-# INLINE runContShiftM #-}
 
@@ -216,12 +216,12 @@ runContShiftWithCPure = runContShiftWithCUnsafe
 --
 -- This is a safe variant of 'runContShiftWithCUnsafe', as this may only be used
 -- as the final interpreter before 'runM'.
-runContShiftWithCM :: (a -> Sem '[Lift m] (Maybe s))
-                   -> Sem [ Cont (Ref (Sem '[Lift m]) (Maybe s))
-                          , Shift (Ref (Sem '[Lift m]) (Maybe s)) s
-                          , Lift m
+runContShiftWithCM :: (a -> Sem '[Embed m] (Maybe s))
+                   -> Sem [ Cont (Ref (Sem '[Embed m]) (Maybe s))
+                          , Shift (Ref (Sem '[Embed m]) (Maybe s)) s
+                          , Embed m
                           ] a
-                   -> Sem '[Lift m] (Maybe s)
+                   -> Sem '[Embed m] (Maybe s)
 runContShiftWithCM = runContShiftWithCUnsafe
 {-# INLINE runContShiftWithCM #-}
 

--- a/src/Polysemy/Shift/Internal.hs
+++ b/src/Polysemy/Shift/Internal.hs
@@ -20,16 +20,16 @@ data Shift ref s m a where
   Reset   :: m s -> Shift ref s m s
   Reset'  :: m s -> Shift ref s m (Maybe s)
 
-makeSem_ ''Shift
+makeSem ''Shift
 
 -----------------------------------------------------------------------------
 -- | Reifies the current continuation in the form of a prompt, and passes it to
 -- the first argument. Unlike 'subst', control will never return to the current
 -- continuation unless the prompt is invoked via 'release'.
-trap :: forall ref s a r
-     .  Member (Shift ref s) r
-     => (ref a -> Sem r s)
-     -> Sem r a
+-- trap :: forall ref s a r
+--      .  Member (Shift ref s) r
+--      => (ref a -> Sem r s)
+--      -> Sem r a
 
 -----------------------------------------------------------------------------
 -- | Provide an answer to a prompt, jumping to its reified continuation.
@@ -49,34 +49,34 @@ trap :: forall ref s a r
 -- The provided continuation may fail locally in its subcontinuations.
 -- It may sometimes become necessary to handle such cases. To do so,
 -- use 'reset\'' together with 'release'.
-invoke :: forall ref a x r
-       .  Member (Shift ref a) r
-       => ref x
-       -> x
-       -> Sem r a
+-- invoke :: forall ref a x r
+--        .  Member (Shift ref a) r
+--        => ref x
+--        -> x
+--        -> Sem r a
 
 
 -----------------------------------------------------------------------------
 -- | Aborts the current continuation with a result.
-abort :: forall ref s a r
-      .  Member (Shift ref s) r
-      => s
-      -> Sem r a
+-- abort :: forall ref s a r
+--       .  Member (Shift ref s) r
+--       => s
+--       -> Sem r a
 
 -----------------------------------------------------------------------------
 -- | Delimits any continuations and calls to 'abort'.
-reset :: forall ref a r
-      .  Member (Shift ref a) r
-      => Sem r a
-      -> Sem r a
+-- reset :: forall ref a r
+--       .  Member (Shift ref a) r
+--       => Sem r a
+--       -> Sem r a
 
 -----------------------------------------------------------------------------
 -- | Delimits any continuations and calls to 'abort', and detects if
 -- any subcontinuation has failed locally.
-reset' :: forall ref s r
-       .  Member (Shift ref s) r
-       => Sem r s
-       -> Sem r (Maybe s)
+-- reset' :: forall ref s r
+--        .  Member (Shift ref s) r
+--        => Sem r s
+--        -> Sem r (Maybe s)
 
 runShiftWeaving :: Monad m
                 => (forall x. (x -> m (Maybe s)) -> Sem r x -> m (Maybe s))

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,7 @@ packages:
 extra-deps:
 - polysemy-0.7.0.0
 - type-errors-0.2.0.0
-- polysemy-plugin-0.2.1.0
+- type-errors-pretty-0.0.0.0
 - th-abstraction-0.3.1.0
 - bifunctors-5.5.4
 - first-class-families-0.5.0.0

--- a/test/ContSpec.hs
+++ b/test/ContSpec.hs
@@ -77,7 +77,7 @@ test5 = do
 
   r <-  runM
       . runContM
-      . runStateInIORef ref
+      . runStateIORef ref
       $ stateTest
   s' <- readIORef ref
   return (r, s')
@@ -93,7 +93,7 @@ test7 :: ([String], String)
 test7 =
     (`C.runCont` id)
   . runFinal
-  . runTraceAsList
+  . runTraceList
   . runReader ""
   . runContFinal
   $ do

--- a/test/FloodgateSpec.hs
+++ b/test/FloodgateSpec.hs
@@ -8,7 +8,7 @@ import Polysemy.Trace
 spec :: Spec
 spec = describe "Floodgate" $ do
   it "should delay held traces until release" $ do
-    let (ts, n) = run . runTraceAsList . runFloodgate $ do
+    let (ts, n) = run . runTraceList . runFloodgate $ do
           hold $ trace "first1"
           hold $ trace "first2"
           trace "not held"

--- a/test/IdempotentLoweringSpec.hs
+++ b/test/IdempotentLoweringSpec.hs
@@ -10,10 +10,10 @@ import Polysemy.Resource
 import Test.Hspec
 
 
-runStateInIO :: Member (Lift IO) r => s -> IO (∀ x. Sem (State s ': r) x -> Sem r x)
+runStateInIO :: Member (Embed IO) r => s -> IO (∀ x. Sem (State s ': r) x -> Sem r x)
 runStateInIO s = do
   ref <- newIORef s
-  nat $ runStateInIORef ref
+  nat $ runStateIORef ref
 
 
 test
@@ -32,7 +32,7 @@ test = do
 spec :: Spec
 spec = describe "Idempotent Lowering" $ do
   it "should persist an IORef through a bracket" $ do
-    runIt <- nat runM .@! const (runStateInIO 0) .@! liftNat runResourceInIO
+    runIt <- nat runM .@! const (runStateInIO 0) .@! liftNat lowerResource
     result <- runIt test
     result `shouldBe` (3 :: Int)
 

--- a/test/SeveralSpec.hs
+++ b/test/SeveralSpec.hs
@@ -54,7 +54,7 @@ runStates :: HList t -> Sem (TypeConcat (TypeMap State t) r) a -> Sem r a
 runStates = runSeveral (fmap (fmap snd) . runState)
 
 runConstInputs :: HList t -> Sem (TypeConcat (TypeMap Input t) r) a -> Sem r a
-runConstInputs = runSeveral runConstInput
+runConstInputs = runSeveral runInputConst
 
 spec :: Spec
 spec = do
@@ -73,11 +73,11 @@ spec = do
     it "should be equivalent to composed runState" $ do
       run original `shouldBe` run new
 
-  describe "runConstInput" $ do
-    let original = runConstInput 5 . runConstInput "test"
-                                   . runConstInput True $ inputProgram
+  describe "runInputConst" $ do
+    let original = runInputConst 5 . runInputConst "test"
+                                   . runInputConst True $ inputProgram
         new = runConstInputs (True ::: "test" ::: 5 ::: HNil) inputProgram
 
-    it "should be equivalent to composed runConstInput" $ do
+    it "should be equivalent to composed runInputConst" $ do
       run original `shouldBe` run new
 

--- a/test/ShiftSpec.hs
+++ b/test/ShiftSpec.hs
@@ -57,7 +57,7 @@ test4 = do
   ref <- newIORef 1
   runM
    . runShiftM
-   . runStateInIORef ref
+   . runStateIORef ref
    $ do
     shift $ \c -> do
       _ <- c ()


### PR DESCRIPTION
This does not compile for me even with polysemy master. See [This actually compiles](https://github.com/Avi-D-coder/polysemy-zoo/commit/e14314f1810eb3bc1c5ee56ca39e3049beaab01a).

3 of 4 `makeSem_` produce errors like the following.
```
polysemy-zoo/src/Polysemy/Shift/Internal.hs:23:1: error:
    • Could not deduce: s ~ a
      from the context: Member (Shift ref a) r
        bound by the type signature for:
                   reset :: forall (ref :: * -> *) a (r :: [(* -> *) -> * -> *]).
                            Member (Shift ref a) r =>
                            Sem r a -> Sem r a
        at src/Polysemy/Shift/Internal.hs:(68,1)-(71,16)
      ‘s’ is a rigid type variable bound by
        an expression type signature:
          forall s. Shift ref s (Sem r) s
        at src/Polysemy/Shift/Internal.hs:23:1-16
      ‘a’ is a rigid type variable bound by
        the type signature for:
          reset :: forall (ref :: * -> *) a (r :: [(* -> *) -> * -> *]).
                   Member (Shift ref a) r =>
                   Sem r a -> Sem r a
        at src/Polysemy/Shift/Internal.hs:(68,1)-(71,16)
      Expected type: Shift ref s (Sem r) s
        Actual type: Shift ref a (Sem r) a
    • In the first argument of ‘Polysemy.Internal.send’, namely
        ‘(Reset x_asQf :: Shift ref s (Sem r) s)’
      In the expression:
        Polysemy.Internal.send (Reset x_asQf :: Shift ref s (Sem r) s)
      In an equation for ‘reset’:
          reset x_asQf
            = Polysemy.Internal.send (Reset x_asQf :: Shift ref s (Sem r) s)
    • Relevant bindings include
        x_asQf :: Sem r a (bound at src/Polysemy/Shift/Internal.hs:23:1)
        reset :: Sem r a -> Sem r a
          (bound at src/Polysemy/Shift/Internal.hs:23:1)
   |
23 | makeSem_ ''Shift

--  While building package polysemy-zoo-0.4.0.1 using:
      /home/user/.stack/setup-exe-cache/x86_64-linux-tinfo6/Cabal-simple_mPHDZzAJ_2.4.0.1_ghc-8.6.5 --builddir=.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1 build lib:polysemy-zoo --ghc-options " -fdiagnostics-color=always"
```

Is the plugin active?
Running `stack build --ghc-options='-fplugin=Polysemy.Plugin'` leads to the same error.