### PR TITLE
Fix revPut and Tagged docs

### DIFF
--- a/src/Polysemy/RevState.hs
+++ b/src/Polysemy/RevState.hs
@@ -50,8 +50,9 @@ revGet = revState $ \s -> (s, s)
 -- | Sends a new state into the past.
 revPut :: forall s r
         . Member (RevState s) r
-       => Sem r s
-revPut = revState $ \s -> (s, s)
+       => s
+       -> Sem r ()
+revPut s = revState $ \_ -> (s, ())
 
 ------------------------------------------------------------------------------
 -- | Gets the state as sent from the next call to 'revState'

--- a/src/Polysemy/Tagged.hs
+++ b/src/Polysemy/Tagged.hs
@@ -36,7 +36,7 @@ newtype Tagged k e m a where
 --             -> 'Sem' r a
 --             -> 'Sem' r a
 -- taggedLocal f m =
---   'tag' @k @('Polysemy.Reader.Reader' i) $ 'Polysemy.Reader.local' @i f ('raise' m)
+--   'tag' \@k \@('Polysemy.Reader.Reader' i) $ 'Polysemy.Reader.local' \@i f ('raise' m)
 -- @
 --
 tag :: forall k e r a


### PR DESCRIPTION
`revPut` was the same as `revGet`. This mistake makes me mad, because I had written the proper definition, and even confirmed it during a double-check. Perhaps while working on `RevState` I reverted to an older version of the file for some reason.

@isovector Is this worth an v0.6.0.1 release? `revPut` is the least important of all `RevState`'s methods; you'd typically use `revModify` instead (since you can't do `revGet >>= revPut . f` without getting into an infinite loop). 