### PR TITLE
Remove Alias.hs and remove InterpreterOf usage

### DIFF
--- a/polysemy-zoo.cabal
+++ b/polysemy-zoo.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 508b2d70f45ca899d68cc756e99c4a93128f7748848feefea756030db96c9c94
+-- hash: f83ddee96f912486d3ab74690af73d22a6e0b40e9cd465f2ed938a77a6b37cd2
 
 name:           polysemy-zoo
 version:        0.6.0.1
@@ -29,7 +29,6 @@ source-repository head
 
 library
   exposed-modules:
-      Polysemy.Alias
       Polysemy.Capture
       Polysemy.ConstraintAbsorber
       Polysemy.ConstraintAbsorber.MonadCont

--- a/src/Polysemy/Alias.hs
+++ b/src/Polysemy/Alias.hs
@@ -1,6 +1,0 @@
-module Polysemy.Alias where
-
-import Polysemy
-
-type InterpreterOf e r = forall x.  Sem (e ': r) x -> Sem r x
-

--- a/src/Polysemy/SetStore.hs
+++ b/src/Polysemy/SetStore.hs
@@ -8,7 +8,6 @@ import           Data.Foldable
 import qualified Data.Set as S
 import qualified Database.Redis as R
 import           Polysemy
-import           Polysemy.Alias
 import           Polysemy.Error
 import           Polysemy.KVStore
 import           Polysemy.Redis.Utils
@@ -27,7 +26,7 @@ runSetStoreAsKVStore
     :: ( Member (KVStore k (S.Set v)) r
        , Ord v
        )
-    => InterpreterOf (SetStore k v) r
+    => Sem (SetStore k v ': r) x -> Sem r x
 runSetStoreAsKVStore = interpret $ \case
   AddS k v ->
     lookupKV k >>= \case
@@ -48,7 +47,7 @@ runSetStoreInRedis
        , Binary v
        )
     => (k -> Path)
-    -> InterpreterOf (SetStore k v) r
+    -> Sem (SetStore k v ': r) x -> Sem r x
 runSetStoreInRedis pf = interpret $ \case
   AddS k v -> void
             . fromEitherM


### PR DESCRIPTION
This PR addresses issue #52 I only found one usage of the `InterpreterOf` alias and removed it as well as the `Alias.hs` file.