### PR TITLE
Added PolySemy.ConstraintAbsorber.MonadCatch and tests.  

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,7 @@ dependencies:
 - random >= 1.1 && <1.2
 - reflection >= 2.1.4 && < 3.0.0
 - transformers >= 0.5.2.0 && < 0.6
+- text >= 1.1.0 && < 1.3 
 - ghc-prim >= 0.5.2 && < 0.6
 - hedis >= 0.10 && < 0.13
 - async >= 2.2 && < 3
@@ -76,5 +77,5 @@ tests:
     - hspec-discover  >= 2.0
     dependencies:
     - polysemy >= 1.2.0.0
-    - polysemy-zoo
+    - polysemy-zoo    
     - hspec >= 2.6.0 && < 3

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                polysemy-zoo
-version:             0.7.0.0
+version:             0.6.0.1
 github:              "isovector/polysemy-zoo"
 license:             BSD3
 author:              "Sandy Maguire"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                polysemy-zoo
-version:             0.6.0.1
+version:             0.7.0.0
 github:              "isovector/polysemy-zoo"
 license:             BSD3
 author:              "Sandy Maguire"
@@ -78,4 +78,3 @@ tests:
     - polysemy >= 1.2.0.0
     - polysemy-zoo
     - hspec >= 2.6.0 && < 3
-    - text > 1.2

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ dependencies:
 - constraints >= 0.10.1 && < 0.12
 - containers >= 0.5 && < 0.7
 - contravariant < 2
+- exceptions >= 0.10.0 && < 0.11
 - mtl >= 2.0.1.0 && < 3.0.0.0
 - polysemy >= 1.2.0.0
 - polysemy-plugin >= 0.2
@@ -77,4 +78,4 @@ tests:
     - polysemy >= 1.2.0.0
     - polysemy-zoo
     - hspec >= 2.6.0 && < 3
-
+    - text > 1.2

--- a/polysemy-zoo.cabal
+++ b/polysemy-zoo.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9da87678c68faabeeb046437d9c4de9dadddaa719cd6207269f1e2bff20e4038
+-- hash: aa67117d6d72f06ce1c742de965c10dade2a32975fca9253525f3e63ffb62d59
 
 name:           polysemy-zoo
-version:        0.7.0.0
+version:        0.6.0.1
 synopsis:       Experimental, user-contributed effects and interpreters for polysemy
 description:    Please see the README on GitHub at <https://github.com/isovector/polysemy-zoo#readme>
 category:       Polysemy

--- a/polysemy-zoo.cabal
+++ b/polysemy-zoo.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aa67117d6d72f06ce1c742de965c10dade2a32975fca9253525f3e63ffb62d59
+-- hash: 7c046b6c3dd1f7ae3dd9b51b7154b8bf5a8a78e654fbb14c0430c2d36684913f
 
 name:           polysemy-zoo
 version:        0.6.0.1
@@ -81,6 +81,7 @@ library
     , polysemy-plugin >=0.2
     , random >=1.1 && <1.2
     , reflection >=2.1.4 && <3.0.0
+    , text >=1.1.0 && <1.3
     , transformers >=0.5.2.0 && <0.6
   default-language: Haskell2010
 
@@ -123,5 +124,6 @@ test-suite polysemy-zoo-test
     , polysemy-zoo
     , random >=1.1 && <1.2
     , reflection >=2.1.4 && <3.0.0
+    , text >=1.1.0 && <1.3
     , transformers >=0.5.2.0 && <0.6
   default-language: Haskell2010

--- a/polysemy-zoo.cabal
+++ b/polysemy-zoo.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 73e0a9b51c2607c1e7635c24228191621207fbbd14b2387c8bf77ddaee4cca46
+-- hash: 9da87678c68faabeeb046437d9c4de9dadddaa719cd6207269f1e2bff20e4038
 
 name:           polysemy-zoo
-version:        0.6.0.1
+version:        0.7.0.0
 synopsis:       Experimental, user-contributed effects and interpreters for polysemy
 description:    Please see the README on GitHub at <https://github.com/isovector/polysemy-zoo#readme>
 category:       Polysemy
@@ -123,6 +123,5 @@ test-suite polysemy-zoo-test
     , polysemy-zoo
     , random >=1.1 && <1.2
     , reflection >=2.1.4 && <3.0.0
-    , text >1.2
     , transformers >=0.5.2.0 && <0.6
   default-language: Haskell2010

--- a/polysemy-zoo.cabal
+++ b/polysemy-zoo.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f83ddee96f912486d3ab74690af73d22a6e0b40e9cd465f2ed938a77a6b37cd2
+-- hash: 73e0a9b51c2607c1e7635c24228191621207fbbd14b2387c8bf77ddaee4cca46
 
 name:           polysemy-zoo
 version:        0.6.0.1
@@ -31,6 +31,7 @@ library
   exposed-modules:
       Polysemy.Capture
       Polysemy.ConstraintAbsorber
+      Polysemy.ConstraintAbsorber.MonadCatch
       Polysemy.ConstraintAbsorber.MonadCont
       Polysemy.ConstraintAbsorber.MonadError
       Polysemy.ConstraintAbsorber.MonadReader
@@ -72,6 +73,7 @@ library
     , constraints >=0.10.1 && <0.12
     , containers >=0.5 && <0.7
     , contravariant <2
+    , exceptions >=0.10.0 && <0.11
     , ghc-prim >=0.5.2 && <0.6
     , hedis >=0.10 && <0.13
     , mtl >=2.0.1.0 && <3.0.0.0
@@ -111,6 +113,7 @@ test-suite polysemy-zoo-test
     , constraints >=0.10.1 && <0.12
     , containers >=0.5 && <0.7
     , contravariant <2
+    , exceptions >=0.10.0 && <0.11
     , ghc-prim >=0.5.2 && <0.6
     , hedis >=0.10 && <0.13
     , hspec >=2.6.0 && <3
@@ -120,5 +123,6 @@ test-suite polysemy-zoo-test
     , polysemy-zoo
     , random >=1.1 && <1.2
     , reflection >=2.1.4 && <3.0.0
+    , text >1.2
     , transformers >=0.5.2.0 && <0.6
   default-language: Haskell2010

--- a/src/Polysemy/ConstraintAbsorber/MonadCatch.hs
+++ b/src/Polysemy/ConstraintAbsorber/MonadCatch.hs
@@ -31,16 +31,15 @@ import qualified Polysemy.Error                as E
 
 
 ------------------------------------------------------------------------------
--- | run function to map something in the Exception hierarchy to SomeException
-{-runErrorForMonadCatch
-  :: forall e r a
-   . (SomeException -> e)
-  -> Sem (E.Error SomeException ': r) a
-  -> Sem r (Either e a)
--}
+-- | Like 'E.runError' but applies a given function from 'SomeException'
+-- to some other type, typically something less opaque.
+-- e.g.:
+--  @runErrorForMonadCatch C.displayException@
+-- 
+-- @since 0.7.0.0
 runErrorForMonadCatch
-  :: (SomeException -> e)
-  -> Sem (E.Error SomeException : E.Error e : r) a
+  :: (C.SomeException -> e)
+  -> Sem (E.Error C.SomeException : E.Error e : r) a
   -> Sem r (Either e a)
 runErrorForMonadCatch f = E.runError . E.mapError f
 

--- a/src/Polysemy/ConstraintAbsorber/MonadCatch.hs
+++ b/src/Polysemy/ConstraintAbsorber/MonadCatch.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE AllowAmbiguousTypes         #-}
+{-# LANGUAGE FlexibleContexts            #-}
+{-# LANGUAGE GADTs                       #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving  #-}
+{-# LANGUAGE RankNTypes                  #-}
+{-# LANGUAGE ScopedTypeVariables         #-}
+{-# LANGUAGE TypeApplications            #-}
+{-# LANGUAGE UndecidableInstances        #-}
+
+module Polysemy.ConstraintAbsorber.MonadCatch
+  (
+    -- * Constraint Absorbers
+    absorbMonadThrow
+  , absorbMonadCatch
+  -- * run helper
+  , runErrorForMonadCatch
+    -- * Re-exports
+  , Exception(..)
+  , SomeException
+  )
+where
+
+import qualified Control.Monad.Catch           as C
+import           Control.Monad.Catch            ( Exception(..)
+                                                , SomeException
+                                                , toException
+                                                )
+import           Polysemy
+import           Polysemy.ConstraintAbsorber
+import qualified Polysemy.Error                as E
+
+
+------------------------------------------------------------------------------
+-- | run function to map something in the Exception hierarchy to SomeException
+{-runErrorForMonadCatch
+  :: forall e r a
+   . (SomeException -> e)
+  -> Sem (E.Error SomeException ': r) a
+  -> Sem r (Either e a)
+-}
+runErrorForMonadCatch
+  :: (SomeException -> e)
+  -> Sem (E.Error SomeException : E.Error e : r) a
+  -> Sem r (Either e a)
+runErrorForMonadCatch f = E.runError . E.mapError f
+
+
+-- | Introduce a local 'S.MonadCatch' constraint on 'Sem' --- allowing it to
+-- interop nicely with exceptions
+--
+-- @since 0.7.0.0
+absorbMonadCatch
+  :: Member (E.Error C.SomeException) r
+  => (C.MonadCatch (Sem r) => Sem r a)
+       -- ^ A computation that requires an instance of 'C.MonadCatch'
+       -- or 'C.MonadThrow' for
+       -- 'Sem'. This might be something with type @'C.MonadCatch' e m => m a@.
+  -> Sem r a
+absorbMonadCatch =
+  absorbWithSem @C.MonadCatch @Action (CatchDict E.throw E.catch) (Sub Dict)
+{-# INLINABLE absorbMonadCatch #-}
+
+-- | Introduce a local 'S.MonadThrow' constraint on 'Sem' --- allowing it to
+-- interop nicely with exceptions
+--
+-- @since 0.7.0.0
+absorbMonadThrow
+  :: Member (E.Error C.SomeException) r
+  => (C.MonadThrow (Sem r) => Sem r a)
+       -- ^ A computation that requires an instance of 'C.MonadCatch'
+       -- or 'C.MonadThrow' for
+       -- 'Sem'. This might be something with type @'C.MonadCatch' e m => m a@.
+  -> Sem r a
+absorbMonadThrow = absorbMonadCatch
+{-# INLINABLE absorbMonadThrow #-}
+
+------------------------------------------------------------------------------
+-- | A dictionary of the functions we need to supply
+-- to make an instance of Error
+data CatchDict m = CatchDict
+  { throwM_ :: forall a. C.SomeException -> m a
+  , catch_ :: forall a. m a -> (C.SomeException -> m a) -> m a
+  }
+
+
+------------------------------------------------------------------------------
+-- | Wrapper for a monadic action with phantom
+-- type parameter for reflection.
+-- Locally defined so that the instance we are going
+-- to build with reflection must be coherent, that is
+-- there cannot be orphans.
+newtype Action m s' a = Action { action :: m a }
+  deriving (Functor, Applicative, Monad)
+
+
+------------------------------------------------------------------------------
+-- | Given a reifiable mtl Error dictionary,
+-- we can make an instance of @MonadError@ for the action
+-- wrapped in @Action@.
+instance ( Monad m
+         , Reifies s' (CatchDict m)
+         ) => C.MonadThrow (Action m s') where
+  throwM e = Action $ throwM_ (reflect $ Proxy @s') (C.toException e)
+  {-# INLINEABLE throwM #-}
+
+instance ( Monad m
+         , Reifies s' (CatchDict m)
+         )  => C.MonadCatch (Action m s') where
+  catch x f =
+    let catchF = catch_ (reflect $ Proxy @s')
+    in Action $ (action x) `catchF` \e -> case C.fromException e of
+      Just e' -> action $ f e'
+      _ -> throwM_ (reflect $ Proxy @s') (C.toException e)
+  {-# INLINEABLE catch #-}
+
+


### PR DESCRIPTION
Here's the PR to resolve https://github.com/polysemy-research/polysemy-zoo/issues/40.

- Adds absorber for ```MonadCatch``` (as well as ```MonadThrow```, but that is a superclass of ```MonadCatch``` so I just use the ```MonadCatch``` absorber for both).  
- Added a custom run-function, ```runErrorForMonadCatch```, as well, because people will usually want to map the ```SomeException``` type to something less opaque so there will almost always be a ```runError . mapError f``` sort of thing and I just made it explicit.  But maybe that's bad form since it's trivial?  The oddness of ```SomeException``` tripped me up a bit in testing so I thought I would add the run function to help others with the same issue.
- Added some tests, throwing exceptions and handling some.
- Added the exceptions package to package.yaml
- Bumped the polysemy-zoo version to 0.7.0.0 in package.yaml as well.  

Note: I didn't attempt to add an absorber for ```MonadMask``` because that gets into asynchronous exceptions, etc. and I don't know much about all that.  But that seems like a useful thing to add in the future if anyone is interested.