### PR TITLE
add polysemy-readline to list of integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Here is a curated list of other great effects and interops:
 
 * [kowainik/co-log](https://github.com/kowainik/co-log/tree/master/co-log-polysemy)
 * [adamConnerSax/polysemy-RandomFu](https://hackage.haskell.org/package/polysemy-RandomFu)
-
+* [lehmacdj/polysemy-readline](https://hackage.haskell.org/package/polysemy-readline)


### PR DESCRIPTION
I've just released `polysemy-readline` version `0.2.0.0` on hackage and am happy enough with it to want to advertise it publicly here. It provides an effect that offers compatibility with the `haskeline` package.